### PR TITLE
Fix some stuff regarding selfhosted runners and performance

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -52,14 +52,14 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CHUNKS_PATH: ../chunks/chunks.json
       CHUNK_NUMBER: ${{ matrix.chunk }}
-      CHUNK_COUNT: 5
+      CHUNK_COUNT: 1
 
     strategy:
       fail-fast: false
       matrix:
         engine: [v8, jsc, sm, chakra, hermes, kiesel, porffor, libjs, engine262, qjs, qjs_ng, xs, graaljs, nashorn, rhino, boa, nova, babel, swc, sucrase] # all
 
-        chunk: [0, 1, 2, 3, 4]
+        chunk: [0]
         # engine: [v8, jsc, sm, chakra, hermes, kiesel, libjs, qjs, xs, graaljs] # exclude hangers/long
         # engine: [chakra, graaljs, jsc, kiesel, libjs, qjs, xs] # all fast
         # engine: [v8, jsc, sm, chakra] # just major

--- a/scripts/engines/babel.sh
+++ b/scripts/engines/babel.sh
@@ -17,4 +17,4 @@ cd ..
 
 node helpers/babel/version.js > version.txt
 
-./scripts/test262.sh node "$(pwd)/node-v0.10.48-linux-x64/bin/node" 4 "$(pwd)/helpers/babel/preprocessor.js" "$(pwd)/helpers/babel/transformer.js"
+./scripts/test262.sh node "$(pwd)/node-v0.10.48-linux-x64/bin/node" 8 "$(pwd)/helpers/babel/preprocessor.js" "$(pwd)/helpers/babel/transformer.js"

--- a/scripts/engines/kiesel.sh
+++ b/scripts/engines/kiesel.sh
@@ -2,4 +2,4 @@
 
 curl -L -o version.txt https://files.kiesel.dev/version.txt
 ./scripts/install/esvu.sh kiesel
-./scripts/test262.sh kiesel "${HOME}/.esvu/bin/kiesel" 32
+./scripts/test262.sh kiesel "${HOME}/.esvu/bin/kiesel" 16

--- a/scripts/engines/porffor.sh
+++ b/scripts/engines/porffor.sh
@@ -9,4 +9,4 @@ git rev-parse HEAD > ../version.txt
 npm install
 cd ..
 
-./scripts/test262.sh porffor "$(pwd)/helpers/porffor.sh" 16
+./scripts/test262.sh porffor "$(pwd)/helpers/porffor.sh" 8

--- a/scripts/engines/qjs.sh
+++ b/scripts/engines/qjs.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 ./scripts/install/jsvu.sh quickjs
-./scripts/test262.sh qjs "${HOME}/.jsvu/bin/quickjs" 32
+./scripts/test262.sh qjs "${HOME}/.jsvu/bin/quickjs" 16

--- a/scripts/engines/qjs_ng.sh
+++ b/scripts/engines/qjs_ng.sh
@@ -6,4 +6,4 @@ jsvu --os=linux64 --engines=quickjs
 
 cp "$HOME/.jsvu/status.json" "jsvu.json"
 
-./scripts/test262.sh qjs "${HOME}/.jsvu/bin/quickjs" 32
+./scripts/test262.sh qjs "${HOME}/.jsvu/bin/quickjs" 16

--- a/scripts/engines/sm.sh
+++ b/scripts/engines/sm.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 ./scripts/install/jsvu.sh spidermonkey
-./scripts/test262.sh jsshell "${HOME}/.jsvu/bin/sm" 32
+./scripts/test262.sh jsshell "${HOME}/.jsvu/bin/sm" 16

--- a/scripts/engines/sm_exp.sh
+++ b/scripts/engines/sm_exp.sh
@@ -3,4 +3,4 @@
 export JS_EXPERIMENTAL=1
 
 ./scripts/install/jsvu.sh spidermonkey
-./scripts/test262.sh jsshell "${HOME}/.jsvu/bin/sm" 32
+./scripts/test262.sh jsshell "${HOME}/.jsvu/bin/sm" 16

--- a/scripts/engines/sucrase.sh
+++ b/scripts/engines/sucrase.sh
@@ -11,4 +11,4 @@ cd ../..
 
 node helpers/sucrase/version.js > version.txt
 
-./scripts/test262.sh node "$(pwd)/node-v0.10.48-linux-x64/bin/node" 4 "$(pwd)/helpers/sucrase/preprocessor.js" "$(pwd)/helpers/sucrase/transformer.js"
+./scripts/test262.sh node "$(pwd)/node-v0.10.48-linux-x64/bin/node" 8 "$(pwd)/helpers/sucrase/preprocessor.js" "$(pwd)/helpers/sucrase/transformer.js"

--- a/scripts/engines/swc.sh
+++ b/scripts/engines/swc.sh
@@ -9,4 +9,4 @@ tar -zxf node.tar.gz
 
 node helpers/swc/version.js > version.txt
 
-./scripts/test262.sh node "$(pwd)/node-v0.10.48-linux-x64/bin/node" 4 "$(pwd)/helpers/swc/preprocessor.js" "$(pwd)/helpers/swc/transformer.js"
+./scripts/test262.sh node "$(pwd)/node-v0.10.48-linux-x64/bin/node" 8 "$(pwd)/helpers/swc/preprocessor.js" "$(pwd)/helpers/swc/transformer.js"

--- a/scripts/engines/v8.sh
+++ b/scripts/engines/v8.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 ./scripts/install/jsvu.sh v8
-./scripts/test262.sh d8 "${HOME}/.jsvu/bin/v8" 32
+./scripts/test262.sh d8 "${HOME}/.jsvu/bin/v8" 16

--- a/scripts/engines/xs.sh
+++ b/scripts/engines/xs.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 ./scripts/install/jsvu.sh xs
-./scripts/test262.sh xs "${HOME}/.jsvu/bin/xs" 32
+./scripts/test262.sh xs "${HOME}/.jsvu/bin/xs" 16

--- a/scripts/extractResults.sh
+++ b/scripts/extractResults.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-for file in results/*.zip
-do
+for file in results/*.zip; do
   x="$(basename $file .zip)"
   echo "$x"
 

--- a/scripts/test262.sh
+++ b/scripts/test262.sh
@@ -19,11 +19,20 @@ if ! [[ -f ../hash && "$(cat ../hash)" == "$commit" ]]; then # skip reinstalling
 	echo "$commit" > ../hash
 fi
 
-echo running test262...
+echo "running test262..."
 
-start=`date +%s`
-NODE_OPTIONS="--max-old-space-size=4096" test262-harness --host-type="$1" --host-path="$2" --reporter=json --reporter-keys=file,result,scenario,attrs --timeout=6000 --threads=$3 --preprocessor="$4" --transformer="$5" "test/**/*.js" > "../results$CHUNK_NUMBER.json"
-end=`date +%s`
+start=$(date +%s)
+NODE_OPTIONS="--max-old-space-size=4096" test262-harness \
+	--host-type="$1" \
+	--host-path="$2" \
+	--reporter=json \
+	--reporter-keys=file,result,scenario,attrs \
+	--timeout=6000 \
+	--threads=$3 \
+	--preprocessor="$4" \
+	--transformer="$5" \
+	"test/**/*.js" > "../results$CHUNK_NUMBER.json"
+end=$(date +%s)
 
 echo "$((end-start))" > "../time$CHUNK_NUMBER.txt"
 

--- a/scripts/test262.sh
+++ b/scripts/test262.sh
@@ -1,12 +1,23 @@
-#!/bin/sh
+#!/bin/bash
 set -x
 
-# clone test262
-git clone https://github.com/tc39/test262.git --depth 1
-cd ./test262
+if [[ ! -d test262 ]]; then
+	# clone test262
+	git clone https://github.com/tc39/test262.git --depth 1
+	cd test262
+else
+	# it already exists, just pull
+	cd test262
+	git pull
+fi
+
+commit="$(git rev-parse HEAD)"
 
 # install test262 harness (our fork - https://github.com/CanadaHonk/test262-harness)
-npm install -g github:CanadaHonk/test262-harness
+if ! [[ -f ../hash && "$(cat ../hash)" == "$commit" ]]; then # skip reinstalling if nothing changed
+	npm install -g github:CanadaHonk/test262-harness
+	echo "$commit" > ../hash
+fi
 
 echo running test262...
 


### PR DESCRIPTION
I've run some benchmarks this morning! [See here for my notes](https://md.sakamoto.pl/8eJEyHjrQyi1NhHKEJ3Qzw).

The current idea / plan:

- runner has 20 vCores and 16GB RAM (increased from 16 vCores and 12GB RAM which caused an OOM yesterday)
- decrease the amount of runners; yesterday there were 6, I'm gonna decrease that to 4 (most tests are tested to provide around 60% CPU usage cumulatively, but some are `fork()`-bound, and only take 10-20%; I lack enough data to know if 4 runners is gonna be the right amount, but I *think* it's gonna provide a good balance between getting all the perf we can and not loosing too much on task-switching
- get rid of chunks; This will heavily help with speed for engines that have to be compiled, as we won't waste time recompiling the same thing for the nth time.

---

Rest of the changes are a bit more opinionated; When re-running the same thing over and over for testing, I noticed `git` being unhappy about already having a directory, plus `npm` taking its sweet time to re-check dependencies on an already installed package. This should chip off a couple seconds from each run (not a lot, but I suspect it may add up quite quickly :3)

FWIW this still runs the npm install for esvu for *every engine*, but - small steps :p 