### PR TITLE
Fix boa script `version.txt` output location

### DIFF
--- a/scripts/engines/boa.sh
+++ b/scripts/engines/boa.sh
@@ -7,4 +7,4 @@ git ls-remote ${URL}.git HEAD | cut -f1 > ../version.txt
 curl -L -o boa ${URL}/releases/download/nightly/boa-x86_64-unknown-linux-gnu
 chmod +x boa
 
-./scripts/test262.sh boa "$(pwd)" 24
+./scripts/test262.sh boa "$(pwd)/boa" 24

--- a/scripts/engines/boa.sh
+++ b/scripts/engines/boa.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 URL=https://github.com/boa-dev/boa
-git ls-remote ${URL}.git HEAD | cut -f1 > ../version.txt
+git ls-remote ${URL}.git HEAD | cut -f1 > version.txt
 
 # download release
 curl -L -o boa ${URL}/releases/download/nightly/boa-x86_64-unknown-linux-gnu


### PR DESCRIPTION
There was a bug with the first #90 where the output location of the `version.txt` was not corrected, to be the current directory. This fixes that issue and reverts #91 