### PR TITLE
Add graaljs_exp (GraalJS with experimental options)

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        engine: [v8, v8_exp, jsc, jsc_exp, sm, sm_exp, chakra, hermes, kiesel, libjs, engine262, qjs, qjs_ng, xs, graaljs, rhino, boa, nova, njs, babel, swc, sucrase] # all
+        engine: [v8, v8_exp, jsc, jsc_exp, sm, sm_exp, chakra, hermes, kiesel, libjs, engine262, qjs, qjs_ng, xs, graaljs, graaljs_exp, rhino, boa, nova, njs, babel, swc, sucrase] # all
 
         chunk: [0, 1]
         # engine: [v8, jsc, sm, chakra, hermes, kiesel, libjs, qjs, xs, graaljs] # exclude hangers/long

--- a/scripts/downloadOldResults.mjs
+++ b/scripts/downloadOldResults.mjs
@@ -1,6 +1,6 @@
 import { writeFileSync, mkdirSync, existsSync } from 'fs';
 
-const { artifacts } = await (await fetch('https://api.github.com/repos/CanadaHonk/test262.fyi/actions/artifacts', { headers: { Authorization: 'Bearer ' + process.env.GITHUB_TOKEN }})).json();
+const { artifacts } = await (await fetch('https://api.github.com/repos/test262-fyi/test262.fyi/actions/artifacts', { headers: { Authorization: 'Bearer ' + process.env.GITHUB_TOKEN }})).json();
 
 if (!existsSync('results')) mkdirSync('results');
 console.log(artifacts.map(x => x.name));

--- a/scripts/engines/graaljs_exp.sh
+++ b/scripts/engines/graaljs_exp.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+export JS_EXPERIMENTAL=1
+
+./scripts/install/jsvu.sh graaljs
+./scripts/test262.sh graaljs "${HOME}/.jsvu/bin/graaljs" 32

--- a/site/index.html
+++ b/site/index.html
@@ -70,6 +70,7 @@
       qjs_ng: 'QuickJS NG',
       libjs: 'LibJS',
       graaljs: 'GraalJS',
+      graaljs_exp: 'GraalJS 🧪⚙️',
       xs: 'XS',
       rhino: 'Rhino',
       engine262: 'engine262',
@@ -95,6 +96,7 @@
       chakra: 'Former JS engine for Edge',
       libjs: 'JS engine from SerenityOS, also used in Ladybird browser',
       graaljs: 'Built on GraalVM',
+      graaljs_exp: 'GraalJS with experimental options',
       engine262: 'ECMA262 in JavaScript!',
       rhino: 'Java JS engine by Mozilla',
       boa: 'Experimental embeddable JS engine in Rust',
@@ -121,6 +123,7 @@
       qjs_ng: 'QJS-NG',
       libjs: 'LJS',
       graaljs: 'Graal',
+      graaljs_exp: 'Graal🧪',
       xs: 'XS',
       rhino: 'Rhino',
       engine262: 'e262',
@@ -141,13 +144,13 @@
       sucrase: 'transformers'
     };
 
-    const niceEngineOrder = [ 'v8', 'v8_exp', 'jsc', 'jsc_exp', 'sm', 'sm_exp', 'hermes', 'qjs', 'qjs_ng', 'libjs', 'chakra', 'graaljs', 'xs', 'rhino', 'boa', 'kiesel', 'porffor', 'nova', 'njs', 'engine262', 'bali', 'babel', 'swc', 'sucrase' ];
+    const niceEngineOrder = [ 'v8', 'v8_exp', 'jsc', 'jsc_exp', 'sm', 'sm_exp', 'hermes', 'qjs', 'qjs_ng', 'libjs', 'chakra', 'graaljs', 'graaljs_exp', 'xs', 'rhino', 'boa', 'kiesel', 'porffor', 'nova', 'njs', 'engine262', 'bali', 'babel', 'swc', 'sucrase' ];
 
     const thead = document.querySelector('thead');
     const tbody = document.querySelector('tbody');
 
     // Update filterOutEngines.length below when changing this list
-    let cwd = '', filterOutEngines = [ 'v8_exp', 'sm_exp', 'jsc_exp', 'chakra', 'xs', 'rhino', 'boa', 'qjs_ng', 'engine262', 'kiesel', 'porffor', 'nova', 'njs', 'bali', 'swc', 'sucrase' ], init = false;
+    let cwd = '', filterOutEngines = [ 'v8_exp', 'sm_exp', 'jsc_exp', 'chakra', 'graaljs_exp', 'xs', 'rhino', 'boa', 'qjs_ng', 'engine262', 'kiesel', 'porffor', 'nova', 'njs', 'bali', 'swc', 'sucrase' ], init = false;
     const defaultFilterLen = filterOutEngines.length;
 
     if (location.hash) {

--- a/site/style.css
+++ b/site/style.css
@@ -188,6 +188,11 @@ thead .stats {
   color: #000408;
 }
 
+.stat-graaljs_exp {
+  background: #f88c96;
+  color: #000408;
+}
+
 .stat-babel {
   background: #f8c10d;
   color: #000408;
@@ -245,6 +250,7 @@ thead .stats {
 .no-stat-jsc #content .stat-jsc,
 .no-stat-chakra #content .stat-chakra,
 .no-stat-graaljs #content .stat-graaljs,
+.no-stat-graaljs_exp #content .stat-graaljs_exp,
 .no-stat-hermes #content .stat-hermes,
 .no-stat-kiesel #content .stat-kiesel,
 .no-stat-libjs #content .stat-libjs,


### PR DESCRIPTION
Adds `graaljs_exp` engine, i.e. GraalJS with experimental features (follow-up to https://github.com/test262-fyi/eshost/pull/19 that added support for experimental options).

Changes inspired by https://github.com/test262-fyi/test262.fyi/commit/1b805ddda22018a2e3eedeffde20fcf4da7d4a89, but untested!
Let me know if you think adding an experimental mode is too much and you want to keep only one variant of GraalJS.

Also updates the download url in [scripts/downloadOldResults.mjs](https://github.com/test262-fyi/test262.fyi/pull/94/files#diff-fbd741ced43a3b6053605cd4b367e167163814149ff840f0b277fd1aa2549913)